### PR TITLE
Use vault ID instead of name

### DIFF
--- a/1password_deduplicator.py
+++ b/1password_deduplicator.py
@@ -44,7 +44,7 @@ def username(item):
 
 
 def password(item):
-    cmd = f"op read op://{item['vault']['name']}/{item['id']}/password"
+    cmd = f"op read op://{item['vault']['id']}/{item['id']}/password"
     try:
         return run_command(cmd)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
to prevent issues with spaces and special characters in vault names.